### PR TITLE
fix: 修复移动端通知栏`tooltip`点击穿透问题

### DIFF
--- a/src/layout/components/notice/noticeItem.vue
+++ b/src/layout/components/notice/noticeItem.vue
@@ -2,6 +2,7 @@
 import { ListItem } from "./data";
 import { ref, PropType, nextTick } from "vue";
 import { useNav } from "@/layout/hooks/useNav";
+import { deviceDetection } from "@pureadmin/utils";
 
 const props = defineProps({
   noticeItem: {
@@ -15,6 +16,7 @@ const titleTooltip = ref(false);
 const descriptionRef = ref(null);
 const descriptionTooltip = ref(false);
 const { tooltipEffect } = useNav();
+const isMobile = deviceDetection();
 
 function hoverTitle() {
   nextTick(() => {
@@ -63,6 +65,7 @@ function hoverDescription(event, description) {
           :disabled="!titleTooltip"
           :content="props.noticeItem.title"
           placement="top-start"
+          :enterable="!isMobile"
         >
           <div
             ref="titleRef"


### PR DESCRIPTION
哈喽，移动端通知栏点击tooltip的时候会出现点击穿透导致外层下拉框被关闭的情况; 所以我在h5的环境下给tooltip加了个禁止enterable的判断，看下是否可行，截图在issues中