### PR TITLE
fix: 修复导航tab过多导致关闭左侧标签页无法正常显示

### DIFF
--- a/src/layout/components/tag/index.vue
+++ b/src/layout/components/tag/index.vue
@@ -193,13 +193,13 @@ function deleteDynamicTag(obj: any, current: any, tag?: string) {
   ): void => {
     if (other) {
       useMultiTagsStoreHook().handleTags("equal", [routerArrays[0], obj]);
-      dynamicTagView();
     } else {
       delAliveRouteList = useMultiTagsStoreHook().handleTags("splice", "", {
         startIndex,
         length
       }) as any;
     }
+    dynamicTagView();
   };
 
   if (tag === "other") {


### PR DESCRIPTION
导航tab打开过多，会导致点击关闭左侧标签页后，剩余的标签栏无法正常显示出来。

https://user-images.githubusercontent.com/74349832/220542511-875b1108-6119-476c-af98-c75ce09b6bb5.mp4

