### PR TITLE
fix: 修复路由跳转,参数相同的情况下,标签页同时高亮的问题

### DIFF
--- a/src/layout/hooks/useTag.ts
+++ b/src/layout/hooks/useTag.ts
@@ -120,9 +120,15 @@ export function useTags() {
   function conditionHandle(item, previous, next) {
     if (isBoolean(route?.meta?.showLink) && route?.meta?.showLink === false) {
       if (Object.keys(route.query).length > 0) {
-        return isEqual(route.query, item.query) ? previous : next;
+        return isEqual(route.query, item.query) &&
+          isEqual(route.path, item.path)
+          ? previous
+          : next;
       } else {
-        return isEqual(route.params, item.params) ? previous : next;
+        return isEqual(route.params, item.params) &&
+          isEqual(route.path, item.path)
+          ? previous
+          : next;
       }
     } else {
       return route.path === item.path ? previous : next;


### PR DESCRIPTION
### 问题
![动画](https://user-images.githubusercontent.com/33746006/222085654-b56d9b0d-4da4-4444-b265-d345ace3ec20.gif)
![image](https://user-images.githubusercontent.com/33746006/222085681-1b8df59f-cfb4-4737-8b9f-fc335450545f.png)
### 复现步骤
将src\views\tabs\hooks.ts文件做以下修改,跳转路径不同,参数相同,模拟此问题的场景
![image](https://user-images.githubusercontent.com/33746006/222086114-f95d5299-f135-4fa4-b7ce-d533ffe0f52d.png)
