### PR TITLE
fix: 修复在混合模式下刷新页签后，左侧菜单会消失闪一下的问题

### DIFF
--- a/src/layout/components/sidebar/vertical.vue
+++ b/src/layout/components/sidebar/vertical.vue
@@ -60,6 +60,7 @@ onBeforeMount(() => {
 watch(
   () => [route.path, usePermissionStoreHook().wholeMenus],
   () => {
+    if (route.path.includes("/redirect")) return;
     getSubMenuData(route.path);
     menuSelect(route.path, routers);
   }


### PR DESCRIPTION
视频如下，混合模式下刷新页签，左侧菜单会失联

https://github.com/pure-admin/vue-pure-admin/assets/31479917/2240c50c-8793-4dd3-afb3-cef8d97fbbee

