### PR TITLE
顶部搜索弹窗优化

### DIFF
--- a/src/layout/components/search/components/SearchModal.vue
+++ b/src/layout/components/search/components/SearchModal.vue
@@ -99,6 +99,7 @@ function handleUp() {
 
 /** key down */
 function handleDown() {
+  inputRef.value.blur();
   const { length } = resultOptions.value;
   if (length === 0) return;
   const index = resultOptions.value.findIndex(
@@ -113,6 +114,7 @@ function handleDown() {
 
 /** key enter */
 function handleEnter() {
+  inputRef.value.blur();
   const { length } = resultOptions.value;
   if (length === 0 || activePath.value === "") return;
   router.push(activePath.value);

--- a/src/layout/components/search/components/SearchResult.vue
+++ b/src/layout/components/search/components/SearchResult.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed } from "vue";
+import { computed, nextTick, ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import { useEpThemeStoreHook } from "@/store/modules/epTheme";
 import { useRenderIcon } from "@/components/ReIcon/src/hooks";
@@ -49,6 +49,29 @@ const active = computed({
   }
 });
 
+const isInViewport = element => {
+  const rect = element.getBoundingClientRect();
+  return (
+    rect.top >= 0 &&
+    rect.left >= 0 &&
+    rect.bottom <=
+      (window.innerHeight || document.documentElement.clientHeight) &&
+    rect.right <= (window.innerWidth || document.documentElement.clientWidth)
+  );
+};
+
+watch(
+  () => props.value,
+  () => {
+    nextTick(() => {
+      const dom = resultRef.value.querySelector(".active-item");
+      if (!isInViewport(dom)) {
+        dom.scrollIntoView();
+      }
+    });
+  }
+);
+
 /** 鼠标移入 */
 async function handleMouse(item) {
   active.value = item.path;
@@ -60,10 +83,11 @@ function handleTo() {
 </script>
 
 <template>
-  <div class="result">
+  <div class="result" ref="resultRef">
     <template v-for="item in options" :key="item.path">
       <div
         class="result-item dark:bg-[#1d1d1d]"
+        :class="{ 'active-item': item.path === active }"
         :style="itemStyle(item)"
         @click="handleTo"
         @mouseenter="handleMouse(item)"


### PR DESCRIPTION
针对顶部点击搜索出现的弹窗，如果搜索的结果数据过多，一个屏幕显示不全，按上下键选中项超出视图后，会在视图外继续滚动，体验不好，故加此优化，使选中项始终保持在可视范围内！

https://github.com/pure-admin/vue-pure-admin/assets/36908524/beb66d34-47e4-44ae-9fd4-0ffbf4400b5e

