### PR TITLE
perf: 优化菜单搜索弹窗高度

### DIFF
--- a/src/layout/components/search/components/SearchModal.vue
+++ b/src/layout/components/search/components/SearchModal.vue
@@ -164,7 +164,7 @@ onKeyStroke("ArrowDown", handleDown);
       </template>
     </el-input>
     <div class="search-result-container">
-      <el-scrollbar ref="scrollbarRef" max-height="600px">
+      <el-scrollbar ref="scrollbarRef" max-height="calc(90vh - 140px)">
         <el-empty
           v-if="resultOptions.length === 0"
           description="暂无搜索结果"


### PR DESCRIPTION
搜索弹窗的top为5vh，为底部预留相同的5vh，去掉弹窗的头部和底部固定高度剩下的即为中间滚动区域的最大高度