### PR TITLE
feat: 移除多余的env配置项

### DIFF
--- a/.env.staging
+++ b/.env.staging
@@ -1,6 +1,6 @@
 # 预发布也需要生产环境的行为
 # https://cn.vitejs.dev/guide/env-and-mode.html#modes
-NODE_ENV=production
+# NODE_ENV = development
 
 VITE_PUBLIC_PATH = /
 


### PR DESCRIPTION
`vite build`命令中不需要将NODE_ENV设置为production，参考链接：
https://cn.vitejs.dev/guide/migration.html#production-builds-by-default

此pr也可消除执行`build:staging`时的警告消息：

> NODE_ENV=production is not supported in the .env file. Only NODE_ENV=development is supported to create a development build of your project. If you need to set process.env.NODE_ENV, you can set it in the Vite config instead.