### PR TITLE
fix: config中serverConfig.json的配置路径修改

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -31,7 +31,7 @@ export const getServerConfig = async (app: App): Promise<undefined> => {
   app.config.globalProperties.$config = getConfig();
   return axios({
     method: "get",
-    url: `${VITE_PUBLIC_PATH}serverConfig.json`
+    url: `${VITE_PUBLIC_PATH}/serverConfig.json`
   })
     .then(({ data: config }) => {
       let $config = app.config.globalProperties.$config;


### PR DESCRIPTION
**部署后，发现404，文件地址拼接错误**

<img width="1143" alt="image" src="https://github.com/pure-admin/vue-pure-admin/assets/75007029/b7e456dc-896a-4d21-8b35-36362cd30850">
