### PR TITLE
perf: 消除警告提示，在添加的动态路由页面刷新后，因为没有获取到该动态路由会出现警告信息

### DIFF
--- a/src/router/modules/remaining.ts
+++ b/src/router/modules/remaining.ts
@@ -38,5 +38,13 @@ export default [
       showLink: false,
       rank: 103
     }
+  },
+  // 消除警告提示，在添加的动态路由页面刷新后，因为没有获取到该动态路由会出现警告信息
+  {
+    path: "/:catchAll(.*)",
+    component: () => import("@/views/error/404.vue"),
+    meta: {
+      showLink: false
+    }
   }
 ] as Array<RouteConfigsTable>;


### PR DESCRIPTION
![WeChat1b6d3e64f5b5697d929d891e43243947](https://github.com/pure-admin/vue-pure-admin/assets/26428338/10aab016-dd6b-4a31-b50f-8f22b387987c)

警告信息如上图，系统：macos-13.4，浏览器firefox-113.0.2
