### PR TITLE
fix: github information in home page

### DIFF
--- a/src/views/welcome/index.vue
+++ b/src/views/welcome/index.vue
@@ -145,7 +145,9 @@ getReleases().then(({ data }) => {
           </template>
           <el-skeleton animated :rows="7" :loading="loading">
             <template #default>
-              <Github />
+              <el-scrollbar :height="`calc(${height}px - 35vh - 340px)`">
+                <Github />
+              </el-scrollbar>
             </template>
           </el-skeleton>
         </el-card>


### PR DESCRIPTION
不加scrollbar的话有展示问题。
![image](https://github.com/pure-admin/vue-pure-admin/assets/36768323/2e42947d-835a-43c9-8d16-7506484c9e90)
