### PR TITLE
feat: 首页GitHub信息表格新增滚动组件

### DIFF
--- a/src/views/welcome/index.vue
+++ b/src/views/welcome/index.vue
@@ -144,9 +144,11 @@ getReleases().then(({ data }) => {
             </a>
           </template>
           <el-skeleton animated :rows="7" :loading="loading">
-            <template #default>
-              <Github />
-            </template>
+            <el-scrollbar :height="`calc(${height}px - 35vh - 340px)`">
+              <template #default>
+                <Github />
+              </template>
+            </el-scrollbar>
           </el-skeleton>
         </el-card>
       </el-col>


### PR DESCRIPTION
目前首页GitHub信息表格区域超出无法滚动，添加滚动组件能让隐藏区域正常滚动