### PR TITLE
fix: 修复首页echarts图表resize失效问题

### DIFF
--- a/src/views/welcome/components/Bar.vue
+++ b/src/views/welcome/components/Bar.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref, computed, watch, type Ref } from "vue";
-import { useAppStoreHook } from "@/store/modules/app";
+import { useSettingStoreHook } from "@/store/modules/settings";
 import {
   delay,
   useDark,
@@ -19,6 +19,8 @@ const barChartRef = ref<HTMLDivElement | null>(null);
 const { setOptions, resize } = useECharts(barChartRef as Ref<HTMLDivElement>, {
   theme
 });
+
+const pureSetting = useSettingStoreHook();
 
 setOptions(
   {
@@ -125,7 +127,7 @@ setOptions(
 );
 
 watch(
-  () => useAppStoreHook().getSidebarStatus,
+  () => pureSetting.hiddenSideBar,
   () => {
     delay(600).then(() => resize());
   }

--- a/src/views/welcome/components/Line.vue
+++ b/src/views/welcome/components/Line.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { useIntervalFn } from "@vueuse/core";
 import { ref, computed, watch, type Ref } from "vue";
-import { useAppStoreHook } from "@/store/modules/app";
+import { useSettingStoreHook } from "@/store/modules/settings";
 import {
   delay,
   useDark,
@@ -20,6 +20,8 @@ const { setOptions, getInstance, resize } = useECharts(
   lineChartRef as Ref<HTMLDivElement>,
   { theme }
 );
+
+const pureSetting = useSettingStoreHook();
 
 const xData = (() => {
   const data: any[] = [];
@@ -175,7 +177,7 @@ useIntervalFn(() => {
 }, 2000);
 
 watch(
-  () => useAppStoreHook().getSidebarStatus,
+  () => pureSetting.hiddenSideBar,
   () => {
     delay(600).then(() => resize());
   }

--- a/src/views/welcome/components/Pie.vue
+++ b/src/views/welcome/components/Pie.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref, computed, watch, type Ref } from "vue";
-import { useAppStoreHook } from "@/store/modules/app";
+import { useSettingStoreHook } from "@/store/modules/settings";
 import {
   delay,
   useDark,
@@ -18,6 +18,8 @@ const pieChartRef = ref<HTMLDivElement | null>(null);
 const { setOptions, resize } = useECharts(pieChartRef as Ref<HTMLDivElement>, {
   theme
 });
+
+const pureSetting = useSettingStoreHook();
 
 setOptions(
   {
@@ -69,7 +71,7 @@ setOptions(
 );
 
 watch(
-  () => useAppStoreHook().getSidebarStatus,
+  () => pureSetting.hiddenSideBar,
   () => {
     delay(600).then(() => resize());
   }


### PR DESCRIPTION
首页目前三个echarts图表在点击 内容区全屏 的时候会出现resize事件没有触发的问题，导致切换屏幕时图表会溢出可视区域。
具体复现路径：依次点击 全屏、内容区全屏、退出全屏、内容区退出全屏，会出现如截图所示情况。