### PR TITLE
fix: 当路由存在query并单击tag触发tags标签切换时，会调用两次router跳转

### DIFF
--- a/src/layout/components/tag/index.scss
+++ b/src/layout/components/tag/index.scss
@@ -247,7 +247,7 @@
 .card-in {
   color: var(--el-color-primary);
 
-  a {
+  .tag-title {
     color: var(--el-color-primary);
   }
 }
@@ -257,7 +257,7 @@
   color: #666;
   border: none;
 
-  a {
+  .tag-title {
     color: #666;
   }
 }

--- a/src/layout/components/tag/index.scss
+++ b/src/layout/components/tag/index.scss
@@ -90,7 +90,7 @@
     }
   }
 
-  a {
+  .tag-title {
     padding: 0 4px;
     color: var(--el-text-color-primary);
     text-decoration: none;
@@ -204,7 +204,7 @@
     transform: translate(0, -50%);
   }
 
-  a {
+  .tag-title {
     color: var(--el-color-primary) !important;
   }
 }

--- a/src/layout/components/tag/index.vue
+++ b/src/layout/components/tag/index.vue
@@ -534,12 +534,11 @@ onBeforeUnmount(() => {
           @mouseleave.prevent="onMouseleave(index)"
           @click="tagOnClick(item)"
         >
-          <router-link
-            :to="item.path"
-            class="dark:!text-text_color_primary dark:hover:!text-primary"
+          <span
+            class="dark:!text-text_color_primary dark:hover:!text-primary tag-title"
           >
             {{ transformI18n(item.meta.title) }}
-          </router-link>
+          </span>
           <span
             v-if="
               iconIsActive(item, index) ||

--- a/src/layout/components/tag/index.vue
+++ b/src/layout/components/tag/index.vue
@@ -535,7 +535,7 @@ onBeforeUnmount(() => {
           @click="tagOnClick(item)"
         >
           <span
-            class="dark:!text-text_color_primary dark:hover:!text-primary tag-title"
+            class="tag-title dark:!text-text_color_primary dark:hover:!text-primary"
           >
             {{ transformI18n(item.meta.title) }}
           </span>


### PR DESCRIPTION
## 问题描述

tag中作为标题使用的原标签为router-link，这对于不含params或query的路由跳转没有影响，

但当标签页tag对应的页面route存在params或query时，由于router-link自带的对click事件的处理，tag自定义绑定的点击事件“@click="tagOnClick(item)”会与router-link同时对tag的点击事件进行响应和处理，从而导致两次router跳转，这可以通过router.beforeEach函数断点监测到。
## 问题复现

发现缘由，我在一个页面的组件挂载函数中定义了通过query中的数据初始化页面数据的函数，结果函数报错提示undefined（被catch了没有导致页面出错），但是使用tag菜单的软刷新后，又恢复正常。于是发现了这个bug。以下是简单的复现过程：

① 启动完整版后，打开先三个标签

![image](https://github.com/pure-admin/vue-pure-admin/assets/30810222/3b18a519-39e4-4b29-bf1c-03c43efd270c)

② 在src/router/index.ts 的 router.beforEach 处 打个 log breakpoint

③ 从“标签页操作”页面，跳转到“No.1 详细信息”

![QQ图片20230712100535](https://github.com/pure-admin/vue-pure-admin/assets/30810222/56a35c4f-6573-4ea5-9553-bc9d30ffd546)

可以看到控制台在同一时间会输出两次，第一次为router-link的跳转，不带query；第二次为tag定义的处理函数的跳转，带上了query。

## 问题修复
将router-link改成其他html标签即可解决这个小bug，不过css样式也得跟着改

![QQ截图20230712102625](https://github.com/pure-admin/vue-pure-admin/assets/30810222/626dbd0c-329f-4851-9a65-6a351fffc280)
