### PR TITLE
fix: 使用endWith来匹配白名单

### DIFF
--- a/src/utils/http/index.ts
+++ b/src/utils/http/index.ts
@@ -74,7 +74,7 @@ class PureHttp {
         }
         /** 请求白名单，放置一些不需要token的接口（通过设置请求白名单，防止token过期后再请求造成的死循环问题） */
         const whiteList = ["/refreshToken", "/login"];
-        return whiteList.some(v => config.url.indexOf(v) > -1)
+        return whiteList.some(v => config.url.endsWith(v))
           ? config
           : new Promise(resolve => {
               const data = getToken();


### PR DESCRIPTION
在对接后端的时候发现 `config.url.indexOf(v) > -1 `比较不准确。
比如`const whiteList = ["/login"];`  
如果后端的请求链接是  `/loginInfo` 或者  `login/list ` 或者 `/loginByWechat`  会造成误判。  
使用`endsWith `会比较准确一点。  