### PR TITLE
perf: 页面初始化时先加载`pinia`再加载`router`，兼容更多使用场景

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -46,10 +46,10 @@ import { Auth } from "@/components/ReAuth";
 app.component("Auth", Auth);
 
 getServerConfig(app).then(async config => {
+  setupStore(app);
   app.use(router);
   await router.isReady();
   injectResponsiveStorage(app, config);
-  setupStore(app);
   app
     .use(MotionPlugin)
     .use(useI18n)


### PR DESCRIPTION
使用中发现，如果路由中有涉及使用到store里的变量， 且想做持久化时；会由于先加载路由后加载store ，导致持久化失败；
所以mian 里初始化 应该按顺序 加载plugin（如果有依赖关系）。
