### PR TITLE
fix: 修复路由跳转,标签页同时高亮的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "mockjs": "^1.1.0",
     "nprogress": "^0.2.0",
     "path": "^0.12.7",
+    "path-to-regexp": "^6.2.1",
     "pinia": "^2.1.4",
     "pinyin-pro": "^3.15.2",
     "qrcode": "^1.5.3",

--- a/src/layout/components/sidebar/vertical.vue
+++ b/src/layout/components/sidebar/vertical.vue
@@ -59,7 +59,7 @@ watch(
   () => {
     if (route.path.includes("/redirect")) return;
     getSubMenuData();
-    menuSelect(route.path);
+    menuSelect(route.path, route.query, route.params);
   }
 );
 

--- a/src/layout/hooks/useNav.ts
+++ b/src/layout/hooks/useNav.ts
@@ -114,9 +114,9 @@ export function useNav() {
     }
   }
 
-  function menuSelect(indexPath: string) {
+  function menuSelect(indexPath: string, query: any, params: any) {
     if (wholeMenus.value.length === 0 || isRemaining(indexPath)) return;
-    emitter.emit("changLayoutRoute", indexPath);
+    emitter.emit("changLayoutRoute", { path: indexPath, query, params });
   }
 
   /** 判断路径是否参与菜单 */

--- a/src/store/modules/multiTags.ts
+++ b/src/store/modules/multiTags.ts
@@ -69,20 +69,16 @@ export const useMultiTagsStore = defineStore({
             const tagPath = tagVal.path;
             // 判断tag是否已存在
             const tagHasExits = this.multiTags.some(tag => {
-              return tag.path === tagPath;
+              return (
+                tag.path === tagPath &&
+                isEqual(
+                  { query: tag.query ?? {}, params: tag.params ?? {} },
+                  { query: tagVal.query ?? {}, params: tagVal.params ?? {} }
+                )
+              );
             });
 
-            // 判断tag中的query键值是否相等
-            const tagQueryHasExits = this.multiTags.some(tag => {
-              return isEqual(tag?.query, tagVal?.query);
-            });
-
-            // 判断tag中的params键值是否相等
-            const tagParamsHasExits = this.multiTags.some(tag => {
-              return isEqual(tag?.params, tagVal?.params);
-            });
-
-            if (tagHasExits && tagQueryHasExits && tagParamsHasExits) return;
+            if (tagHasExits) return;
 
             // 动态路由可打开的最大数量
             const dynamicLevel = tagVal?.meta?.dynamicLevel ?? -1;

--- a/src/utils/mitt.ts
+++ b/src/utils/mitt.ts
@@ -7,7 +7,7 @@ type Events = {
   tagViewsChange: string;
   tagViewsShowModel: string;
   logoChange: boolean;
-  changLayoutRoute: string;
+  changLayoutRoute: { path: string; query: any; params: any };
   imageInfo: {
     img: HTMLImageElement;
     height: number;


### PR DESCRIPTION
## 问题描述
菜单内的页面使用不同的query或params打开时，标签页会同时高亮
曾经好像有个PR提过，但是修复的不彻底 #465 
## 问题复现
复现流程很简单，修改mock数据里asyncRoutes中tabs传参的showLink为true，然后进tabs页面同时打开两个以上页面

![QQ截图20230725153031](https://github.com/pure-admin/vue-pure-admin/assets/30810222/8792e0ba-9b77-4017-a289-660653ebe221)

不同query，相同path的标签同时高亮

![QQ截图20230725154030](https://github.com/pure-admin/vue-pure-admin/assets/30810222/4582905a-e341-4f50-a67a-344c13a20963)

不同params，相同path的标签却都没有高亮

![QQ截图20230725154124](https://github.com/pure-admin/vue-pure-admin/assets/30810222/3669a95c-fb13-4f3d-984c-871bd83baeea)

## 问题本质及修复
Bug似乎是在[https://github.com/pure-admin/vue-pure-admin/commit/facb09d7794129a62c60d5a5a16354c5ffc8f01f](url)这个commit提交中引入的，这个commit虽然修复了相同页面内跳转标签高亮的问题,却也引入了以上两个问题.

这个commit想修复问题的本质是在route跳转过程中,emitter只传递了path信息,而没有传递query和params信息,导致添加到MultiTags Store中的route只有path信息而没有params信息,所以本应该高亮的标签才会被conditionHandler判定为inActive.
所以只要稍稍修改emmiter传值就可从本质上解决这个问题.

其次是对handler的判定方法做出修改,只判断path肯定是不够的,会像上面的commit一样引入同时高亮的bug.
还应该判断query和params, 即 path, query, params三者,任一一个属性不同,就代表着页面不同.

这里在实现中存在过一些问题,route中存储着的是页面的完整路径,而multiTags存储的是格式化路径,我在修改的文件中添加了注释,彻底解决的办法是像vue-router那样使用path-to-regexp来判断,当然如果添加一个新依赖略显麻烦的话,可以将判定逻辑修改为先判定query是否一样,然后判定params,若params存在则只比对params,否则比对path,最后返回结果,debug测试也能实现效果,但是否会出现其他bug就不太清楚了.

## 测试站点
[https://styunlen.cn/pure/](https://styunlen.cn/pure/)