### PR TITLE
refactor: 重构新标签页打开逻辑

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -97,7 +97,7 @@ export function resetRouter() {
 }
 
 /** 路由白名单 */
-const whiteList = ["/login"];
+const whiteList = ["/login", "/newTab"];
 
 const { VITE_HIDE_HOME } = import.meta.env;
 
@@ -111,7 +111,7 @@ router.beforeEach((to: ToRouteType, _from, next) => {
   }
   const userInfo = storageSession().getItem<DataInfo<number>>(sessionKey);
   NProgress.start();
-  const externalLink = isUrl(to?.name as string);
+  const externalLink = isUrl(to?.name as string) || to?.meta?.newTab;
   if (!externalLink) {
     to.matched.some(item => {
       if (!item.meta.title) return "";
@@ -135,9 +135,16 @@ router.beforeEach((to: ToRouteType, _from, next) => {
       next({ path: "/error/404" });
     }
     if (_from?.name) {
-      // name为超链接
+      // 新标签页中打开
       if (externalLink) {
-        openLink(to?.name as string);
+        // 路由映射
+        const routeObj = { Chat: "chat" };
+        let name = to?.name as string;
+        const baseUrl = document.baseURI.split("#")[0];
+        if (Object.keys(routeObj).includes(name)) {
+          name = baseUrl + "#/" + routeObj[name];
+        }
+        openLink(name);
         NProgress.done();
       } else {
         toCorrectRoute();

--- a/types/router.d.ts
+++ b/types/router.d.ts
@@ -31,6 +31,8 @@ declare global {
     frameSrc?: string;
     /** `iframe`页是否开启首次加载动画（默认`true`）`可选` */
     frameLoading?: boolean;
+    /** 是否在新标签中打开 */
+    newTab?: boolean;
     /** 页面加载动画（有两种形式，一种直接采用vue内置的`transitions`动画，另一种是使用`animate.css`写进、离场动画）`可选` */
     transition?: {
       /**
@@ -101,5 +103,5 @@ declare global {
 
 // https://router.vuejs.org/zh/guide/advanced/meta.html#typescript
 declare module "vue-router" {
-  interface RouteMeta extends CustomizeRouteMeta {}
+  interface RouteMeta extends CustomizeRouteMeta { }
 }


### PR DESCRIPTION
#696 
项目中遇到一种情况，有一个路由是无layout的页面，想在打开这个路由时在新标签中打开。
由于不是外链，所以现在项目中的写法没法支持，手动改了一些代码，现在功能能实现了。
提这个pr的目的是想让您看看这个写法是否可行。
谢谢。
