### PR TITLE
perf: 优化removeToken中的session调用

### DIFF
--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -70,7 +70,7 @@ export function setToken(data: DataInfo<Date>) {
 /** 删除`token`以及key值为`user-info`的session信息 */
 export function removeToken() {
   Cookies.remove(TokenKey);
-  sessionStorage.clear();
+  storageSession().clear();
 }
 
 /** 格式化token（jwt格式） */


### PR DESCRIPTION
`sessionStorage.clear();` 破坏了对`session`的的封装，如果之后`storageSession()`修改后可能会导致行为不一致.