### PR TITLE
fix: 修復 refresh 失效重定向至登錄頁，並新增 login 導向原頁面

### DIFF
--- a/mock/refreshToken.ts
+++ b/mock/refreshToken.ts
@@ -5,13 +5,15 @@ export default [
   {
     url: "/refresh-token",
     method: "post",
+    statusCode: 401,
     response: ({ body }) => {
-      if (body.refreshToken) {
+      const refreshToken = "eyJhbGciOiJIUzUxMiJ9.newAdminRefresh";
+      if (body.refreshToken && body.refreshToken === refreshToken) {
         return {
           success: true,
           data: {
             accessToken: "eyJhbGciOiJIUzUxMiJ9.newAdmin",
-            refreshToken: "eyJhbGciOiJIUzUxMiJ9.newAdminRefresh",
+            refreshToken,
             // `expires`选择这种日期格式是为了方便调试，后端直接设置时间戳或许更方便（每次都应该递增）。如果后端返回的是时间戳格式，前端开发请来到这个目录`src/utils/auth.ts`，把第`38`行的代码换成expires = data.expires即可。
             expires: "2023/10/30 23:59:59"
           }

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,6 +1,6 @@
 import "@/utils/sso";
 import Cookies from "js-cookie";
-import { getConfig } from "@/config";
+import { getConfig, responsiveStorageNameSpace } from "@/config";
 import NProgress from "@/utils/progress";
 import { transformI18n } from "@/plugins/i18n";
 import { buildHierarchyTree } from "@/utils/tree";
@@ -193,6 +193,9 @@ router.beforeEach((to: ToRouteType, _from, next) => {
         next();
       } else {
         removeToken();
+        storageLocal().setItem(`${responsiveStorageNameSpace()}redirect`, {
+          path: to.path
+        });
         next({ path: "/login" });
       }
     } else {

--- a/src/router/utils.ts
+++ b/src/router/utils.ts
@@ -366,6 +366,15 @@ function getTopMenu(tag = false): menuType {
   return topMenu;
 }
 
+function getRedirectMenu(tag = false, redirectPath: string): menuType {
+  const redirectMenu = usePermissionStoreHook().wholeMenus.find(
+    item => item.redirect === redirectPath
+  );
+  if (redirectMenu)
+    tag && useMultiTagsStoreHook().handleTags("push", redirectMenu);
+  return redirectMenu;
+}
+
 export {
   hasAuth,
   getAuths,
@@ -373,6 +382,7 @@ export {
   filterTree,
   initRouter,
   getTopMenu,
+  getRedirectMenu,
   addPathMatch,
   isOneOfArray,
   getHistoryMode,

--- a/src/store/modules/user.ts
+++ b/src/store/modules/user.ts
@@ -8,6 +8,7 @@ import { getLogin, refreshTokenApi } from "@/api/user";
 import { UserResult, RefreshTokenResult } from "@/api/user";
 import { useMultiTagsStoreHook } from "@/store/modules/multiTags";
 import { type DataInfo, setToken, removeToken, userKey } from "@/utils/auth";
+import { responsiveStorageNameSpace } from "@/config";
 
 export const useUserStore = defineStore({
   id: "pure-user",
@@ -72,6 +73,9 @@ export const useUserStore = defineStore({
       removeToken();
       useMultiTagsStoreHook().handleTags("equal", [...routerArrays]);
       resetRouter();
+      storageLocal().setItem(`${responsiveStorageNameSpace()}redirect`, {
+        path: router.currentRoute.value.fullPath
+      });
       router.push("/login");
     },
     /** 刷新`token` */

--- a/src/utils/http/index.ts
+++ b/src/utils/http/index.ts
@@ -12,6 +12,7 @@ import {
 import { stringify } from "qs";
 import NProgress from "../progress";
 import { getToken, formatToken } from "@/utils/auth";
+import { message } from "@/utils/message";
 import { useUserStoreHook } from "@/store/modules/user";
 
 // 相关配置请参考：www.axios-js.com/zh-cn/docs/#axios-request-config-1
@@ -88,10 +89,19 @@ class PureHttp {
                     useUserStoreHook()
                       .handRefreshToken({ refreshToken: data.refreshToken })
                       .then(res => {
-                        const token = res.data.accessToken;
-                        config.headers["Authorization"] = formatToken(token);
-                        PureHttp.requests.forEach(cb => cb(token));
-                        PureHttp.requests = [];
+                        if (res.success) {
+                          const token = res.data.accessToken;
+                          config.headers["Authorization"] = formatToken(token);
+                          PureHttp.requests.forEach(cb => cb(token));
+                          PureHttp.requests = [];
+                        } else {
+                          message("登录失效，请重新登入", { type: "error" });
+                          useUserStoreHook().logOut();
+                        }
+                      })
+                      .catch(() => {
+                        message("登录失效，请重新登入", { type: "error" });
+                        useUserStoreHook().logOut();
                       })
                       .finally(() => {
                         PureHttp.isRefreshing = false;

--- a/src/utils/http/index.ts
+++ b/src/utils/http/index.ts
@@ -73,7 +73,7 @@ class PureHttp {
           return config;
         }
         /** 请求白名单，放置一些不需要token的接口（通过设置请求白名单，防止token过期后再请求造成的死循环问题） */
-        const whiteList = ["/refreshToken", "/login"];
+        const whiteList = ["/refresh-token", "/login"];
         return whiteList.find(url => url === config.url)
           ? config
           : new Promise(resolve => {

--- a/src/utils/responsive.ts
+++ b/src/utils/responsive.ts
@@ -8,6 +8,10 @@ export const injectResponsiveStorage = (app: App, config: PlatformConfigs) => {
   const nameSpace = responsiveStorageNameSpace();
   const configObj = Object.assign(
     {
+      // 登入後 redirect 路徑
+      redirect: Storage.getData("redirect", nameSpace) ?? {
+        path: ""
+      },
       // 国际化 默认中文zh
       locale: Storage.getData("locale", nameSpace) ?? {
         locale: config.Locale ?? "zh"

--- a/src/views/login/index.vue
+++ b/src/views/login/index.vue
@@ -10,6 +10,7 @@ import {
 } from "vue";
 import { useI18n } from "vue-i18n";
 import Motion from "./utils/motion";
+import { useGlobal } from "@pureadmin/utils";
 import { useRouter } from "vue-router";
 import { message } from "@/utils/message";
 import { loginRules } from "./utils/rule";
@@ -24,7 +25,7 @@ import { $t, transformI18n } from "@/plugins/i18n";
 import { operates, thirdParty } from "./utils/enums";
 import { useLayout } from "@/layout/hooks/useLayout";
 import { useUserStoreHook } from "@/store/modules/user";
-import { initRouter, getTopMenu } from "@/router/utils";
+import { initRouter, getTopMenu, getRedirectMenu } from "@/router/utils";
 import { bg, avatar, illustration } from "./utils/static";
 import { ReImageVerify } from "@/components/ReImageVerify";
 import { useRenderIcon } from "@/components/ReIcon/src/hooks";
@@ -42,6 +43,8 @@ import Info from "@iconify-icons/ri/information-line";
 defineOptions({
   name: "Login"
 });
+
+const { $storage } = useGlobal<GlobalPropertiesApi>();
 
 const imgCode = ref("");
 const loginDay = ref(7);
@@ -78,7 +81,14 @@ const onLogin = async (formEl: FormInstance | undefined) => {
           if (res.success) {
             // 获取后端路由
             initRouter().then(() => {
-              router.push(getTopMenu(true).path);
+              const redirect = $storage.redirect.path;
+              const redirectMenu = getRedirectMenu(true, redirect);
+              router.push(
+                redirect && redirectMenu
+                  ? redirectMenu.path
+                  : getTopMenu(true).path
+              );
+              $storage.redirect = { path: "" };
               message("登录成功", { type: "success" });
             });
           }

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -140,12 +140,16 @@ declare global {
       };
     };
     username?: string;
+    path?: string;
   }
 
   /**
    * `responsive-storage` 本地响应式 `storage` 的类型声明
    */
   interface ResponsiveStorage {
+    redirect: {
+      path?: string;
+    };
     locale: {
       locale?: string;
     };


### PR DESCRIPTION
修復 #761 問題，同時新增 redirect storage 紀錄重定向頁面
只要是執行 useUserStoreHook().logOut() 都會紀錄，並在登錄時回到原頁面
在登錄頁輸入非白名單 router 也會記錄起來，登錄時判斷 redirect 有無存在於動態路由裡，沒有的話將導至 topMenu