### PR TITLE
fix: 接口`/refreshToken`改为`/refresh-token`

### DIFF
--- a/src/utils/http/index.ts
+++ b/src/utils/http/index.ts
@@ -73,7 +73,7 @@ class PureHttp {
           return config;
         }
         /** 请求白名单，放置一些不需要token的接口（通过设置请求白名单，防止token过期后再请求造成的死循环问题） */
-        const whiteList = ["/refreshToken", "/login"];
+        const whiteList = ["/refresh-token", "/login"];
         return whiteList.find(url => url === config.url)
           ? config
           : new Promise(resolve => {


### PR DESCRIPTION
https://github.com/pure-admin/vue-pure-admin/issues/761#issuecomment-1770297957 頁面切換失效，經測試後是 /refreshToken 寫錯造成的
https://github.com/pure-admin/vue-pure-admin/blob/main/src/api/user.ts#L38
https://github.com/pure-admin/vue-pure-admin/blob/main/src/utils/http/index.ts#L76

另外補充一下，目前沒有任何針對 refresh 錯誤做出對應措施