### PR TITLE
feat: `ReCountTo`普通数字动画组件添加前缀、整数、小数点、小数类名，方便定制

### DIFF
--- a/src/components/ReCountTo/src/normal/index.tsx
+++ b/src/components/ReCountTo/src/normal/index.tsx
@@ -119,12 +119,12 @@ export default defineComponent({
           state.printVal =
             state.localStartVal -
             (state.localStartVal - endVal) *
-              (progress / (state.localDuration as number));
+            (progress / (state.localDuration as number));
         } else {
           state.printVal =
             state.localStartVal +
             (endVal - state.localStartVal) *
-              (progress / (state.localDuration as number));
+            (progress / (state.localDuration as number));
         }
       }
       if (unref(getCountDown)) {
@@ -153,7 +153,15 @@ export default defineComponent({
           x1 = x1.replace(rgx, "$1" + separator + "$2");
         }
       }
-      return prefix + x1 + x2 + suffix;
+      return (
+        <>
+          {prefix && <span class={"count-prefix"}>{prefix}</span>}
+          {x1 && <span class={"count-integer"}>{x1}</span>}
+          {x2 && <span class={"count-decimal-point"}>{decimal}</span>}
+          {x2 && <span class={"count-decimal"}>{x2}</span>}
+          {suffix && <span class={"count-suffix"}>{suffix}</span>}
+        </>
+      );
     }
 
     onMounted(() => {


### PR DESCRIPTION
普通数字动画组件添加前缀、整数、小数点、小数类名，配合vue样式穿透实现数字各部分的样式定制
![image](https://github.com/pure-admin/vue-pure-admin/assets/103236950/9f0875f9-2242-4b3e-aa05-517e98adfca1)
