### PR TITLE
refactor: 优化主题色

### DIFF
--- a/public/platform-config.json
+++ b/public/platform-config.json
@@ -7,7 +7,7 @@
   "KeepAlive": true,
   "Locale": "zh",
   "Layout": "vertical",
-  "Theme": "default",
+  "Theme": "light",
   "DarkMode": false,
   "Grey": false,
   "Weak": false,

--- a/src/layout/components/panel/index.vue
+++ b/src/layout/components/panel/index.vue
@@ -120,7 +120,7 @@ onBeforeUnmount(() => {
   right: 0;
   z-index: 40000;
   width: 100%;
-  max-width: 300px;
+  max-width: 280px;
   height: 100vh;
   box-shadow: 0 0 15px 0 rgb(0 0 0 / 5%);
   transition: all 0.25s cubic-bezier(0.7, 0.3, 0.1, 1);

--- a/src/layout/components/setting/index.vue
+++ b/src/layout/components/setting/index.vue
@@ -194,7 +194,8 @@ function setLayoutModel(layout: string) {
     theme: layoutTheme.value.theme,
     darkMode: $storage.layout?.darkMode,
     sidebarStatus: $storage.layout?.sidebarStatus,
-    epThemeColor: $storage.layout?.epThemeColor
+    epThemeColor: $storage.layout?.epThemeColor,
+    themeColor: layoutTheme.value.theme
   };
   useAppStoreHook().setLayout(layout);
 }

--- a/src/layout/components/setting/index.vue
+++ b/src/layout/components/setting/index.vue
@@ -411,7 +411,7 @@ onBeforeMount(() => {
     cursor: pointer;
     border-radius: 4px;
 
-    &:nth-child(2) {
+    &:nth-child(1) {
       border: 1px solid #ddd;
     }
   }

--- a/src/layout/components/sidebar/leftCollapse.vue
+++ b/src/layout/components/sidebar/leftCollapse.vue
@@ -66,6 +66,6 @@ const toggleClick = () => {
   width: 100%;
   height: 40px;
   line-height: 40px;
-  box-shadow: 0 0 6px -2px var(--el-color-primary);
+  box-shadow: 0 0 6px -3px var(--el-color-primary);
 }
 </style>

--- a/src/layout/hooks/useDataThemeChange.ts
+++ b/src/layout/hooks/useDataThemeChange.ts
@@ -26,8 +26,6 @@ export function useDataThemeChange() {
     { color: "#f5222d", themeColor: "dusk" },
     /* 橙红色 */
     { color: "#fa541c", themeColor: "volcano" },
-    /* 金色 */
-    { color: "#fadb14", themeColor: "yellow" },
     /* 绿宝石 */
     { color: "#13c2c2", themeColor: "mingQing" },
     /* 酸橙绿 */

--- a/src/layout/hooks/useDataThemeChange.ts
+++ b/src/layout/hooks/useDataThemeChange.ts
@@ -18,10 +18,14 @@ import {
 export function useDataThemeChange() {
   const { layoutTheme, layout } = useLayout();
   const themeColors = ref<Array<themeColorsType>>([
-    /* 道奇蓝（默认） */
-    { color: "#1b2a47", themeColor: "default" },
     /* 亮白色 */
     { color: "#ffffff", themeColor: "light" },
+    /* 道奇蓝 */
+    { color: "#1b2a47", themeColor: "default" },
+    /* 深紫罗兰色 */
+    { color: "#722ed1", themeColor: "saucePurple" },
+    /* 深粉色 */
+    { color: "#eb2f96", themeColor: "pink" },
     /* 猩红色 */
     { color: "#f5222d", themeColor: "dusk" },
     /* 橙红色 */
@@ -29,11 +33,7 @@ export function useDataThemeChange() {
     /* 绿宝石 */
     { color: "#13c2c2", themeColor: "mingQing" },
     /* 酸橙绿 */
-    { color: "#52c41a", themeColor: "auroraGreen" },
-    /* 深粉色 */
-    { color: "#eb2f96", themeColor: "pink" },
-    /* 深紫罗兰色 */
-    { color: "#722ed1", themeColor: "saucePurple" }
+    { color: "#52c41a", themeColor: "auroraGreen" }
   ]);
 
   const { $storage } = useGlobal<GlobalPropertiesApi>();

--- a/src/layout/hooks/useDataThemeChange.ts
+++ b/src/layout/hooks/useDataThemeChange.ts
@@ -48,17 +48,23 @@ export function useDataThemeChange() {
   }
 
   /** 设置导航主题色 */
-  function setLayoutThemeColor(theme = getConfig().Theme ?? "default") {
+  function setLayoutThemeColor(
+    theme = getConfig().Theme ?? "light",
+    isClick = true
+  ) {
     layoutTheme.value.theme = theme;
     toggleTheme({
       scopeName: `layout-theme-${theme}`
     });
+    // 如果非isClick，保留之前的themeColor
+    const storageThemeColor = $storage.layout.themeColor;
     $storage.layout = {
       layout: layout.value,
       theme,
       darkMode: dataTheme.value,
       sidebarStatus: $storage.layout?.sidebarStatus,
-      epThemeColor: $storage.layout?.epThemeColor
+      epThemeColor: $storage.layout?.epThemeColor,
+      themeColor: isClick ? theme : storageThemeColor
     };
 
     if (theme === "default" || theme === "light") {
@@ -91,14 +97,17 @@ export function useDataThemeChange() {
   /** 亮色、暗色整体风格切换 */
   function dataThemeChange() {
     if (useEpThemeStoreHook().epTheme === "light" && dataTheme.value) {
-      setLayoutThemeColor("default");
+      setLayoutThemeColor("default", false);
     } else {
-      setLayoutThemeColor(useEpThemeStoreHook().epTheme);
+      setLayoutThemeColor(useEpThemeStoreHook().epTheme, false);
     }
 
     if (dataTheme.value) {
       document.documentElement.classList.add("dark");
     } else {
+      if ($storage.layout.themeColor === "light") {
+        setLayoutThemeColor("light", false);
+      }
       document.documentElement.classList.remove("dark");
     }
   }

--- a/src/layout/hooks/useLayout.ts
+++ b/src/layout/hooks/useLayout.ts
@@ -24,10 +24,11 @@ export function useLayout() {
     if (!$storage.layout) {
       $storage.layout = {
         layout: $config?.Layout ?? "vertical",
-        theme: $config?.Theme ?? "default",
+        theme: $config?.Theme ?? "light",
         darkMode: $config?.DarkMode ?? false,
         sidebarStatus: $config?.SidebarStatus ?? true,
-        epThemeColor: $config?.EpThemeColor ?? "#409EFF"
+        epThemeColor: $config?.EpThemeColor ?? "#409EFF",
+        themeColor: $config?.Theme ?? "light"
       };
     }
     /** 灰色模式、色弱模式、隐藏标签页 */

--- a/src/layout/index.vue
+++ b/src/layout/index.vue
@@ -68,7 +68,8 @@ function setTheme(layoutModel: string) {
     theme: $storage.layout?.theme,
     darkMode: $storage.layout?.darkMode,
     sidebarStatus: $storage.layout?.sidebarStatus,
-    epThemeColor: $storage.layout?.epThemeColor
+    epThemeColor: $storage.layout?.epThemeColor,
+    themeColor: $storage.layout?.themeColor
   };
 }
 

--- a/src/layout/theme/index.ts
+++ b/src/layout/theme/index.ts
@@ -50,17 +50,6 @@ const themeColors = {
     menuTitleHover: "#fff",
     menuActiveBefore: "#e85f33"
   },
-  yellow: {
-    subMenuActiveText: "#d25f00",
-    menuBg: "#2b2503",
-    menuHover: "#f6da4d",
-    subMenuBg: "#0f0603",
-    subMenuActiveBg: "#f6da4d",
-    menuText: "rgb(254 254 254 / 65%)",
-    sidebarLogo: "#443b05",
-    menuTitleHover: "#fff",
-    menuActiveBefore: "#f6da4d"
-  },
   mingQing: {
     subMenuActiveText: "#fff",
     menuBg: "#032121",

--- a/src/layout/theme/index.ts
+++ b/src/layout/theme/index.ts
@@ -8,7 +8,7 @@ import type { multipleScopeVarsOptions } from "@pureadmin/theme";
 const themeColors = {
   /* 亮白色 */
   light: {
-    subMenuActiveText: "#409eff",
+    subMenuActiveText: "#000000d9",
     menuBg: "#fff",
     menuHover: "#e0ebf6",
     subMenuBg: "#fff",

--- a/src/layout/theme/index.ts
+++ b/src/layout/theme/index.ts
@@ -6,17 +6,7 @@ import type { multipleScopeVarsOptions } from "@pureadmin/theme";
 
 /** 预设主题色 */
 const themeColors = {
-  default: {
-    subMenuActiveText: "#fff",
-    menuBg: "#001529",
-    menuHover: "#4091f7",
-    subMenuBg: "#0f0303",
-    subMenuActiveBg: "#4091f7",
-    menuText: "rgb(254 254 254 / 65%)",
-    sidebarLogo: "#002140",
-    menuTitleHover: "#fff",
-    menuActiveBefore: "#4091f7"
-  },
+  /* 亮白色 */
   light: {
     subMenuActiveText: "#409eff",
     menuBg: "#fff",
@@ -28,50 +18,31 @@ const themeColors = {
     menuTitleHover: "#000",
     menuActiveBefore: "#4091f7"
   },
-  dusk: {
+  /* 道奇蓝 */
+  default: {
     subMenuActiveText: "#fff",
-    menuBg: "#2a0608",
-    menuHover: "#e13c39",
-    subMenuBg: "#000",
-    subMenuActiveBg: "#e13c39",
-    menuText: "rgb(254 254 254 / 65.1%)",
-    sidebarLogo: "#42090c",
-    menuTitleHover: "#fff",
-    menuActiveBefore: "#e13c39"
-  },
-  volcano: {
-    subMenuActiveText: "#fff",
-    menuBg: "#2b0e05",
-    menuHover: "#e85f33",
-    subMenuBg: "#0f0603",
-    subMenuActiveBg: "#e85f33",
+    menuBg: "#001529",
+    menuHover: "#4091f7",
+    subMenuBg: "#0f0303",
+    subMenuActiveBg: "#4091f7",
     menuText: "rgb(254 254 254 / 65%)",
-    sidebarLogo: "#441708",
+    sidebarLogo: "#002140",
     menuTitleHover: "#fff",
-    menuActiveBefore: "#e85f33"
+    menuActiveBefore: "#4091f7"
   },
-  mingQing: {
+  /* 深紫罗兰色 */
+  saucePurple: {
     subMenuActiveText: "#fff",
-    menuBg: "#032121",
-    menuHover: "#59bfc1",
+    menuBg: "#130824",
+    menuHover: "#693ac9",
     subMenuBg: "#000",
-    subMenuActiveBg: "#59bfc1",
+    subMenuActiveBg: "#693ac9",
     menuText: "#7a80b4",
-    sidebarLogo: "#053434",
+    sidebarLogo: "#1f0c38",
     menuTitleHover: "#fff",
-    menuActiveBefore: "#59bfc1"
+    menuActiveBefore: "#693ac9"
   },
-  auroraGreen: {
-    subMenuActiveText: "#fff",
-    menuBg: "#0b1e15",
-    menuHover: "#60ac80",
-    subMenuBg: "#000",
-    subMenuActiveBg: "#60ac80",
-    menuText: "#7a80b4",
-    sidebarLogo: "#112f21",
-    menuTitleHover: "#fff",
-    menuActiveBefore: "#60ac80"
-  },
+  /* 深粉色 */
   pink: {
     subMenuActiveText: "#fff",
     menuBg: "#28081a",
@@ -83,16 +54,53 @@ const themeColors = {
     menuTitleHover: "#fff",
     menuActiveBefore: "#d84493"
   },
-  saucePurple: {
+  /* 猩红色 */
+  dusk: {
     subMenuActiveText: "#fff",
-    menuBg: "#130824",
-    menuHover: "#693ac9",
+    menuBg: "#2a0608",
+    menuHover: "#e13c39",
     subMenuBg: "#000",
-    subMenuActiveBg: "#693ac9",
-    menuText: "#7a80b4",
-    sidebarLogo: "#1f0c38",
+    subMenuActiveBg: "#e13c39",
+    menuText: "rgb(254 254 254 / 65.1%)",
+    sidebarLogo: "#42090c",
     menuTitleHover: "#fff",
-    menuActiveBefore: "#693ac9"
+    menuActiveBefore: "#e13c39"
+  },
+  /* 橙红色 */
+  volcano: {
+    subMenuActiveText: "#fff",
+    menuBg: "#2b0e05",
+    menuHover: "#e85f33",
+    subMenuBg: "#0f0603",
+    subMenuActiveBg: "#e85f33",
+    menuText: "rgb(254 254 254 / 65%)",
+    sidebarLogo: "#441708",
+    menuTitleHover: "#fff",
+    menuActiveBefore: "#e85f33"
+  },
+  /* 绿宝石 */
+  mingQing: {
+    subMenuActiveText: "#fff",
+    menuBg: "#032121",
+    menuHover: "#59bfc1",
+    subMenuBg: "#000",
+    subMenuActiveBg: "#59bfc1",
+    menuText: "#7a80b4",
+    sidebarLogo: "#053434",
+    menuTitleHover: "#fff",
+    menuActiveBefore: "#59bfc1"
+  },
+  /* 酸橙绿 */
+  auroraGreen: {
+    subMenuActiveText: "#fff",
+    menuBg: "#0b1e15",
+    menuHover: "#60ac80",
+    subMenuBg: "#000",
+    subMenuActiveBg: "#60ac80",
+    menuText: "#7a80b4",
+    sidebarLogo: "#112f21",
+    menuTitleHover: "#fff",
+    menuActiveBefore: "#60ac80"
   }
 };
 

--- a/src/layout/theme/index.ts
+++ b/src/layout/theme/index.ts
@@ -23,7 +23,7 @@ const themeColors = {
     menuHover: "#e0ebf6",
     subMenuBg: "#fff",
     subMenuActiveBg: "#e0ebf6",
-    menuText: "#7a80b4",
+    menuText: "rgb(0 0 0 / 60%)",
     sidebarLogo: "#fff",
     menuTitleHover: "#000",
     menuActiveBefore: "#4091f7"

--- a/src/store/modules/epTheme.ts
+++ b/src/store/modules/epTheme.ts
@@ -23,8 +23,6 @@ export const useEpThemeStore = defineStore({
     fill(state) {
       if (state.epTheme === "light") {
         return "#409eff";
-      } else if (state.epTheme === "yellow") {
-        return "#d25f00";
       } else {
         return "#fff";
       }

--- a/src/style/sidebar.scss
+++ b/src/style/sidebar.scss
@@ -193,7 +193,7 @@
     .el-menu .el-menu--inline .el-sub-menu__title,
     & .el-sub-menu .el-menu-item {
       min-width: $sideBarWidth !important;
-      font-size: 12px;
+      font-size: 14px;
       background-color: $subMenuBg !important;
     }
 
@@ -247,7 +247,7 @@
 
       .el-menu-item {
         span {
-          font-size: 12px;
+          font-size: 14px;
         }
       }
     }
@@ -270,7 +270,7 @@
     /* 子菜单中还有子菜单 */
     .el-menu .el-sub-menu__title {
       min-width: $sideBarWidth !important;
-      font-size: 12px;
+      font-size: 14px;
       background-color: $subMenuBg !important;
     }
 
@@ -333,7 +333,7 @@
         background-color: $subMenuBg;
 
         span {
-          font-size: 12px;
+          font-size: 14px;
         }
       }
 
@@ -351,7 +351,7 @@
     /* 子菜单中还有子菜单 */
     .el-menu .el-sub-menu__title {
       min-width: $sideBarWidth !important;
-      font-size: 12px;
+      font-size: 14px;
       background-color: $subMenuBg !important;
 
       &:hover {

--- a/src/style/sidebar.scss
+++ b/src/style/sidebar.scss
@@ -83,7 +83,7 @@
     overflow: hidden;
     font-size: 0;
     background: $menuBg;
-    box-shadow: 0 0 1px #888;
+    border-right: 1px solid var(--pure-border-color);
 
     /* 展开动画 */
     transition: width var(--pure-transition-duration);

--- a/src/utils/responsive.ts
+++ b/src/utils/responsive.ts
@@ -15,11 +15,13 @@ export const injectResponsiveStorage = (app: App, config: PlatformConfigs) => {
       // layout模式以及主题
       layout: Storage.getData("layout", nameSpace) ?? {
         layout: config.Layout ?? "vertical",
-        theme: config.Theme ?? "default",
+        theme: config.Theme ?? "light",
         darkMode: config.DarkMode ?? false,
         sidebarStatus: config.SidebarStatus ?? true,
-        epThemeColor: config.EpThemeColor ?? "#409EFF"
+        epThemeColor: config.EpThemeColor ?? "#409EFF",
+        themeColor: config.Theme ?? "light" // 主题色（对应项目配置中的主题色，与theme不同的是它不会受到亮色、暗色整体风格切换的影响，只会在手动点击主题色时改变）
       },
+      // 项目配置-界面显示
       configure: Storage.getData("configure", nameSpace) ?? {
         grey: config.Grey ?? false,
         weak: config.Weak ?? false,

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -1,11 +1,4 @@
-import type {
-  VNode,
-  FunctionalComponent,
-  PropType as VuePropType,
-  ComponentPublicInstance
-} from "vue";
 import type { ECharts } from "echarts";
-import type { IconifyIcon } from "@iconify/vue";
 import type { TableColumns } from "@pureadmin/table";
 
 /**
@@ -129,6 +122,7 @@ declare global {
     hideFooter?: boolean;
     sidebarStatus?: boolean;
     epThemeColor?: string;
+    themeColor?: string;
     showLogo?: boolean;
     showModel?: string;
     mapConfigure?: {
@@ -155,6 +149,7 @@ declare global {
       darkMode?: boolean;
       sidebarStatus?: boolean;
       epThemeColor?: string;
+      themeColor?: string;
     };
     configure: {
       grey?: boolean;

--- a/types/router.d.ts
+++ b/types/router.d.ts
@@ -1,6 +1,7 @@
 // 全局路由类型声明
 
-import { type RouteComponent, type RouteLocationNormalized } from "vue-router";
+import type { RouteComponent, RouteLocationNormalized } from "vue-router";
+import type { FunctionalComponent } from "vue";
 
 declare global {
   interface ToRouteType extends RouteLocationNormalized {


### PR DESCRIPTION
1. 亮白主题色`light`模式下，优化字体颜色，使其更鲜明，如下图
![2001704089015_ pic](https://github.com/pure-admin/vue-pure-admin/assets/44761321/d7568e07-7797-41f7-b627-5a577ee24e34)

2. 移除`yellow`金色主题配色，我的天，辣眼睛，考虑到这种配色几乎没人用将其移除
<img width="1678" alt="image" src="https://github.com/pure-admin/vue-pure-admin/assets/44761321/4bc3c622-fe0d-42f6-b85d-f442b60de2f5">

3. 优化左侧菜单的右边框，使其不再突兀
<img width="713" alt="image" src="https://github.com/pure-admin/vue-pure-admin/assets/44761321/b54eec06-3f7a-4166-b16b-fd4dbcdc75ab">

4. 所有层级的子菜单字体大小跟顶级菜单保持一致都是`14px`
<img width="1165" alt="image" src="https://github.com/pure-admin/vue-pure-admin/assets/44761321/04e3c4a2-3386-4ff1-886b-62052b580b60">

5. 默认亮白`light`主题配色，更符合`pure`纯净的定位，并按照一定的感官调整主题色顺序。当然你也可以按照 [此处代码](https://github.com/pure-admin/vue-pure-admin/pull/842/commits/abfc0cc56593c45cc6d9ff5958799d70ea0b92d7#diff-75aadcbcba4cfc5cbefe74a21eacf0965d82143123eb5efef6c8483a07132399) ，自行调整顺序
<img width="278" alt="image" src="https://github.com/pure-admin/vue-pure-admin/assets/44761321/f810791c-b418-40dc-bf0c-4a5ce3445643">

6. 修复亮白主题配色，切换暗色主题后再切回亮色主题时，无法恢复之前的亮白主题配色

之前：


https://github.com/pure-admin/vue-pure-admin/assets/44761321/c56b1d64-d214-454b-985e-d361749d4f37


之后：

https://github.com/pure-admin/vue-pure-admin/assets/44761321/b347e48f-6968-4718-bdb9-a127fce7ef0e

7. 统一亮白主题配色下顶部菜单和混合菜单的`logo`和右侧操作功能颜色
![2201704188153_ pic](https://github.com/pure-admin/vue-pure-admin/assets/44761321/8db25ae7-cf33-4a9e-a3d6-bfe376b4aca1)
