### PR TITLE
refactor: 替换所有`el-tooltip`为`tippyjs`，它更专业且精致

### DIFF
--- a/src/views/login/index.vue
+++ b/src/views/login/index.vue
@@ -248,13 +248,14 @@ watch(loginDay, value => {
                         <option value="30">30</option>
                       </select>
                       {{ t("login.remember") }}
-                      <el-tooltip
-                        effect="dark"
-                        placement="top"
-                        :content="t('login.rememberInfo')"
-                      >
-                        <IconifyIconOffline :icon="Info" class="ml-1" />
-                      </el-tooltip>
+                      <IconifyIconOffline
+                        v-tippy="{
+                          maxWidth: 430,
+                          content: t('login.rememberInfo')
+                        }"
+                        :icon="Info"
+                        class="ml-1"
+                      />
                     </span>
                   </el-checkbox>
                   <el-button


### PR DESCRIPTION
[tippyjs文档](https://atomiks.github.io/tippyjs/)、[VueTippy文档](https://vue-tippy.netlify.app/)

实际替换中发现 它的定位不是那么完美，暂不替换