### PR TITLE
登录按钮的loading问题

### DIFF
--- a/src/views/login/index.vue
+++ b/src/views/login/index.vue
@@ -77,7 +77,7 @@ const onLogin = async (formEl: FormInstance | undefined) => {
         .then(res => {
           if (res.success) {
             // 获取后端路由
-            initRouter().then(() => {
+            return initRouter().then(() => {
               router.push(getTopMenu(true).path);
               message("登录成功", { type: "success" });
             });


### PR DESCRIPTION
问题原因：
修复获取后端路由因网络原因，未等待initRouter执行完毕，loading已经置为false, 导致按钮可以继续点击；
复现：
延时initRouter函数的返回或切换到3G网可出现
解决：
等待initRouter执行完毕