### PR TITLE
fix: 重新加载时，iframe keepAlive失效

### DIFF
--- a/src/layout/frameView.vue
+++ b/src/layout/frameView.vue
@@ -48,13 +48,16 @@ function init() {
 watch(
   () => currentRoute.fullPath,
   path => {
+    if (
+      currentRoute.name === "Redirect" &&
+      path.includes(props.frameInfo?.fullPath)
+    ) {
+      frameSrc.value = path; // redirect时，置换成任意值，待重定向后 重新赋值
+      loading.value = true;
+    }
+    // 重新赋值
     if (props.frameInfo?.fullPath === path) {
       frameSrc.value = props.frameInfo?.frameSrc;
-    }
-    // 重新加载
-    if (path.indexOf("/redirect/") > -1) {
-      frameSrc.value = props.frameInfo?.fullPath;
-      loading.value = true;
     }
   }
 );


### PR DESCRIPTION
修复`iframe`页面重新加载时，`iframe`缓存失效问题。

刷新当前页面时，`iframeView.vue`中的`iframeSrc`只有是当前页面`path.includes(props.frameInfo?.fullPath) // true`，才重新赋值加载，其余缓存页面做忽略处理。