### PR TITLE
feat: 菜单支持`a`标签右键的所有浏览器行为（在新标签页中、新窗口中打开链接，拖拽到新标签页打开等）

### DIFF
--- a/src/layout/components/sidebar/sidebarItem.vue
+++ b/src/layout/components/sidebar/sidebarItem.vue
@@ -228,30 +228,32 @@ function resolvePath(routePath) {
       {{ overflowSlice(transformI18n(onlyOneChild.meta.title)) }}
     </span>
     <template #title>
-      <div :style="getDivStyle">
-        <span v-if="layout === 'horizontal'">
-          {{ transformI18n(onlyOneChild.meta.title) }}
-        </span>
-        <el-tooltip
-          v-else
-          placement="top"
-          :effect="tooltipEffect"
-          :offset="-10"
-          :disabled="!onlyOneChild.showTooltip"
-        >
-          <template #content>
-            {{ transformI18n(onlyOneChild.meta.title) }}
-          </template>
-          <span
-            ref="menuTextRef"
-            :style="getMenuTextStyle"
-            @mouseover="hoverMenu(onlyOneChild)"
-          >
+      <a style="padding: 0" @click="ev => ev.preventDefault()">
+        <div :style="getDivStyle">
+          <span v-if="layout === 'horizontal'">
             {{ transformI18n(onlyOneChild.meta.title) }}
           </span>
-        </el-tooltip>
-        <extraIcon :extraIcon="onlyOneChild.meta.extraIcon" />
-      </div>
+          <el-tooltip
+            v-else
+            placement="top"
+            :effect="tooltipEffect"
+            :offset="-10"
+            :disabled="!onlyOneChild.showTooltip"
+          >
+            <template #content>
+              {{ transformI18n(onlyOneChild.meta.title) }}
+            </template>
+            <span
+              ref="menuTextRef"
+              :style="getMenuTextStyle"
+              @mouseover="hoverMenu(onlyOneChild)"
+            >
+              {{ transformI18n(onlyOneChild.meta.title) }}
+            </span>
+          </el-tooltip>
+          <extraIcon :extraIcon="onlyOneChild.meta.extraIcon" />
+        </div>
+      </a>
     </template>
   </el-menu-item>
   <el-sub-menu


### PR DESCRIPTION
类似下图：

<img width="372" alt="image" src="https://github.com/pure-admin/vue-pure-admin/assets/44761321/e4413574-b991-44b9-b0b5-5da77ae5c566">
