### PR TITLE
fix: 修复异常的滚动条

### DIFF
--- a/src/layout/components/appMain.vue
+++ b/src/layout/components/appMain.vue
@@ -101,7 +101,7 @@ const transitionMain = defineComponent({
               :view-style="{
                 display: 'flex',
                 flex: 'auto',
-                overflow: 'auto',
+                overflow: 'hidden',
                 'flex-direction': 'column'
               }"
             >


### PR DESCRIPTION
[issue#941](https://github.com/pure-admin/vue-pure-admin/issues/941)

在首页也会出现这个问题，包括横竖滚动条
![image](https://github.com/pure-admin/vue-pure-admin/assets/76251617/1b31318e-de35-4ddc-b985-4b96f67b1c01)
![image](https://github.com/pure-admin/vue-pure-admin/assets/76251617/b940092e-43af-4285-8e1c-e2b827ce9afa)

经过调试，导致出现这个问题的原因在此处（overflow: 'auto' 替换成 'hidden'即可解决）:
![image](https://github.com/pure-admin/vue-pure-admin/assets/76251617/23d73ed4-2cbb-494a-bf43-de3ddf63509b)

还请测试下修改后Mac是否还能正常显示