### PR TITLE
fix: segmented  当v-model值与index不一致时，数据错误

### DIFF
--- a/src/components/ReSegmented/src/index.tsx
+++ b/src/components/ReSegmented/src/index.tsx
@@ -10,7 +10,7 @@ import {
 } from "vue";
 import type { OptionsType } from "./type";
 import { useRenderIcon } from "@/components/ReIcon/src/hooks";
-import { isFunction, isNumber, useDark } from "@pureadmin/utils";
+import { isFunction, useDark } from "@pureadmin/utils";
 
 const props = {
   options: {
@@ -37,18 +37,24 @@ export default defineComponent({
     const curMouseActive = ref(-1);
     const segmentedItembg = ref("");
     const instance = getCurrentInstance()!;
-    const curIndex = isNumber(props.modelValue)
-      ? toRef(props, "modelValue")
-      : ref(0);
+    const curIndex = ref(0);
+    const modelValue = toRef(props, "modelValue");
+    if (modelValue.value) {
+      props.options.forEach((option, index) => {
+        if (option.value === modelValue.value) {
+          curIndex.value = index;
+        }
+      });
+    }
 
     function handleChange({ option, index }, event: Event) {
       if (option.disabled) return;
       event.preventDefault();
-      isNumber(props.modelValue)
-        ? emit("update:modelValue", index)
-        : (curIndex.value = index);
+
+      curIndex.value = index;
       segmentedItembg.value = "";
       emit("change", { index, option });
+      emit("update:modelValue", option.value);
     }
 
     function handleMouseenter({ option, index }, event: Event) {

--- a/src/views/components/segmented.vue
+++ b/src/views/components/segmented.vue
@@ -164,6 +164,7 @@ const optionsChange: Array<OptionsType> = [
     value: 3
   }
 ];
+const modelValue = ref(1);
 
 /** change 事件 */
 function onChange({ index, option }) {
@@ -194,6 +195,13 @@ function onChange({ index, option }) {
       <el-divider />
       <p class="mb-2">change 事件</p>
       <Segmented :options="optionsChange" @change="onChange" />
+      <el-divider />
+      <p class="mb-3">默认值</p>
+      <Segmented
+        v-model="modelValue"
+        :options="optionsChange"
+        @change="onChange"
+      />
       <el-divider />
       <p class="mb-2">禁用</p>
       <Segmented :options="optionsDisabled" />


### PR DESCRIPTION
修改前:
```vue
const optionsChange: Array<OptionsType> = [
  {
    label: "周一",
    value: 1
  },
  {
    label: "周二",
    value: 2
  },
  {
    label: "周三",
    value: 3
  }
];
const modelValue = ref(1);
<p class="mb-2">默认值</p>
<Segmented v-model="modelValue" :options="optionsChange" @change="onChange" />
```

<img width="1252" alt="image" src="https://github.com/pure-admin/vue-pure-admin/assets/33956166/fdea3438-80f5-405d-ac47-205d2e64ef6d">

修改后:
```vue
const optionsChange: Array<OptionsType> = [
  {
    label: "周一",
    value: 1
  },
  {
    label: "周二",
    value: 2
  },
  {
    label: "周三",
    value: 3
  }
];
const modelValue = ref(1);
<p class="mb-2">默认值</p>
<Segmented v-model="modelValue" :options="optionsChange" @change="onChange" />
```
<img width="1252" alt="image" src="https://github.com/pure-admin/vue-pure-admin/assets/33956166/53cb10a8-ee86-4530-ad8c-d669b2f98af7">


**其他数据环境并未测试**