### PR TITLE
feat(components): 为`segmented`组件新增`block`属性，可使其适合父元素宽度

### DIFF
--- a/src/components/ReSegmented/src/index.css
+++ b/src/components/ReSegmented/src/index.css
@@ -64,6 +64,9 @@
   min-height: 28px;
   line-height: 28px;
   padding: 0 11px;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 }
 
 .pure-segmented-item > input {

--- a/src/components/ReSegmented/src/index.css
+++ b/src/components/ReSegmented/src/index.css
@@ -8,6 +8,21 @@
   border-radius: 2px;
 }
 
+.pure-segmented-block {
+  display: flex;
+}
+
+.pure-segmented-block .pure-segmented-item {
+  flex: 1;
+  min-width: 0;
+}
+
+.pure-segmented-block .pure-segmented-item > .pure-segmented-item-label > span {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
 .pure-segmented-group {
   position: relative;
   display: flex;
@@ -49,9 +64,6 @@
   min-height: 28px;
   line-height: 28px;
   padding: 0 11px;
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
 }
 
 .pure-segmented-item > input {
@@ -67,6 +79,7 @@
 .pure-segmented-item-label {
   display: flex;
   align-items: center;
+  justify-content: center;
 }
 
 .pure-segmented-item-icon svg {

--- a/src/components/ReSegmented/src/index.tsx
+++ b/src/components/ReSegmented/src/index.tsx
@@ -8,6 +8,7 @@ import {
   defineComponent,
   getCurrentInstance
 } from "vue";
+import propTypes from "@/utils/propTypes";
 import type { OptionsType } from "./type";
 import { useRenderIcon } from "@/components/ReIcon/src/hooks";
 import { isFunction, isNumber, useDark } from "@pureadmin/utils";
@@ -22,7 +23,9 @@ const props = {
     type: undefined,
     require: false,
     default: "0"
-  }
+  },
+  /** 将宽度调整为父元素宽度	 */
+  block: propTypes.bool.def(false)
 };
 
 export default defineComponent({
@@ -148,7 +151,9 @@ export default defineComponent({
     };
 
     return () => (
-      <div class="pure-segmented">
+      <div
+        class={["pure-segmented", props.block ? "pure-segmented-block" : ""]}
+      >
         <div class="pure-segmented-group">
           <div
             class="pure-segmented-item-selected"

--- a/src/views/components/segmented.vue
+++ b/src/views/components/segmented.vue
@@ -75,6 +75,26 @@ const optionsDisabled: Array<OptionsType> = [
   }
 ];
 
+/** block */
+const optionsBlock: Array<OptionsType> = [
+  {
+    label: "周一"
+  },
+  {
+    label: "周二"
+  },
+  {
+    label: "周三"
+  },
+  {
+    label: "周四"
+  },
+  {
+    label: "周五喜悦，收尾归档，周末倒计时",
+    tip: "周五喜悦，收尾归档，周末倒计时"
+  }
+];
+
 /** 可设置图标 */
 const optionsIcon: Array<OptionsType> = [
   {
@@ -197,6 +217,9 @@ function onChange({ index, option }) {
       <el-divider />
       <p class="mb-2">禁用</p>
       <Segmented :options="optionsDisabled" />
+      <el-divider />
+      <p class="mb-2">block 属性(将宽度调整为父元素宽度)</p>
+      <Segmented :options="optionsBlock" block />
       <el-divider />
       <p class="mb-2">可设置图标</p>
       <Segmented :options="optionsIcon" />


### PR DESCRIPTION
为`ReSegmented`分段控制器新增`block`属性，`block` 属性可以使其适合父元素宽度
在某些场景下，会存在这样的需求，且可以让布局显得更为优美协调，效果同[Ant Design(Segmented)](https://ant.design/components/segmented-cn#segmented-demo-block)


参考图：
![Snipaste_2024-03-19_10-16-46](https://github.com/pure-admin/vue-pure-admin/assets/66454152/3a86e9cf-f8b8-458b-b620-c6927155805c)
