### PR TITLE
chore: 初始化项目prettier路径, 使项目本身的prettier规则生效

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -35,5 +35,6 @@
   "i18n-ally.sourceLanguage": "en",
   "i18n-ally.displayLanguage": "zh-CN",
   "i18n-ally.enabledFrameworks": ["vue"],
-  "iconify.excludes": ["el"]
+  "iconify.excludes": ["el"],
+  "prettier.configPath": ""
 }


### PR DESCRIPTION
#996 ,请注意测试时请确保已经安装了项目依赖包

![2024-03-19_13-25-18](https://github.com/pure-admin/vue-pure-admin/assets/34816426/9da3e806-3c4d-4b40-b375-b4848f62a10c)
