### PR TITLE
chore: revise typo

### DIFF
--- a/src/views/components/cascader.vue
+++ b/src/views/components/cascader.vue
@@ -32,7 +32,7 @@ const handleChange = value => {
         href="https://github.com/pure-admin/vue-pure-admin/blob/main/src/views/components/cascader.vue"
         target="_blank"
       >
-        代码位 src/views/components/cascader.vue
+        代码位置 src/views/components/cascader.vue
       </el-link>
     </template>
     <el-row :gutter="24">

--- a/src/views/components/collapse.vue
+++ b/src/views/components/collapse.vue
@@ -46,7 +46,7 @@ const handleChange = (val: string[]) => {
         href="https://github.com/pure-admin/vue-pure-admin/blob/main/src/views/components/collapse.vue"
         target="_blank"
       >
-        代码位 src/views/components/collapse.vue
+        代码位置 src/views/components/collapse.vue
       </el-link>
     </template>
 

--- a/src/views/components/statistic.vue
+++ b/src/views/components/statistic.vue
@@ -44,7 +44,7 @@ function reset() {
           href="https://github.com/pure-admin/vue-pure-admin/blob/main/src/views/components/statistic.vue"
           target="_blank"
         >
-          代码位 src/views/components/statistic.vue
+          代码位置 src/views/components/statistic.vue
         </el-link>
       </template>
 


### PR DESCRIPTION
admin发布的`5.3.0`整体看了下，有几个模块的文字缺漏，与其他模块不协调(强迫症抓狂！)

文字的查缺补漏：`代码位`=>`代码位置`，
顺便把`演示页加上代码位置提示`涉及的模块都检查了一遍，主要补充了统计组件模块、折叠面板模块、区域级联选择器模块，共计三个模块的文字