### PR TITLE
fix: 调用刷新 `token` 接口报错，重定向处理

### DIFF
--- a/src/utils/http/index.ts
+++ b/src/utils/http/index.ts
@@ -93,6 +93,9 @@ class PureHttp {
                         PureHttp.requests.forEach(cb => cb(token));
                         PureHttp.requests = [];
                       })
+                      .catch(() => {
+                        useUserStoreHook().logOut();
+                      })
                       .finally(() => {
                         PureHttp.isRefreshing = false;
                       });


### PR DESCRIPTION
实际开发中，刷新 token 可能会失效，服务器返回状态码 403 后，需要重定向到登录页。