### PR TITLE
perf: 优化`ReSegmented`组件

### DIFF
--- a/src/components/ReSegmented/src/index.tsx
+++ b/src/components/ReSegmented/src/index.tsx
@@ -127,7 +127,9 @@ export default defineComponent({
       }
     );
 
-    watch(() => props.size, handleResizeInit);
+    watch(() => props.size, handleResizeInit, {
+      immediate: true
+    });
 
     const rendLabel = () => {
       return props.options.map((option, index) => {


### PR DESCRIPTION
修复`ReSegmented`尺寸首次调整造成的样式错位问题

在修复前，它是这样的：
![Kapture 2024-05-08 at 16 58 11](https://github.com/pure-admin/vue-pure-admin/assets/66454152/6624cbf5-3496-448f-b132-5181fc705ba1)


-----------------
现在，它是这样的：

![Kapture 2024-05-08 at 16 59 21](https://github.com/pure-admin/vue-pure-admin/assets/66454152/fbf2111b-5b83-4fac-8874-22f970ff262f)
