### PR TITLE
fix: 修复页面tag激活状态逻辑判断问题

### DIFF
--- a/src/layout/hooks/useTag.ts
+++ b/src/layout/hooks/useTag.ts
@@ -114,15 +114,12 @@ export function useTags() {
   ]);
 
   function conditionHandle(item, previous, next) {
-    if (isBoolean(route?.meta?.showLink) && route?.meta?.showLink === false) {
-      if (Object.keys(route.query).length > 0) {
-        return isEqual(route.query, item.query) ? previous : next;
-      } else {
-        return isEqual(route.params, item.params) ? previous : next;
-      }
-    } else {
-      return route.path === item.path ? previous : next;
-    }
+    const isSamePath = route.path === item.path;
+    const hasQuery = Object.keys(route.query).length > 0;
+    const isSameData = hasQuery
+      ? isEqual(route.query, item.query)
+      : isEqual(route.params, item.params);
+    return isSamePath ? (isSameData ? previous : next) : next;
   }
 
   const iconIsActive = computed(() => {


### PR DESCRIPTION
- 当`showLink`为`false`，传递参数为空时，当前页面路径为`/path1/index1`，其余路径(`showLink:false`)例如：`/path2/index2`,`/path3/index3`等都会显示激活状态