### PR TITLE
perf: 减少代码重复

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -188,15 +188,11 @@ router.beforeEach((to: ToRouteType, _from, next) => {
       toCorrectRoute();
     }
   } else {
-    if (to.path !== "/login") {
-      if (whiteList.indexOf(to.path) !== -1) {
-        next();
-      } else {
-        removeToken();
-        next({ path: "/login" });
-      }
-    } else {
+    if (to.path === "/login" || whiteList.includes(to.path)) {
       next();
+    } else {
+      removeToken();
+      next({ path: "/login" });
     }
   }
 });


### PR DESCRIPTION
减少不必要的嵌套结构，代码更简洁易读
1. 使用 Array.prototype.includes 方法替代 indexOf 进行数组包含判断，这样代码更加语义化。
2. 将路径为 /login 的情况和白名单路径的情况合并为一个条件判断，减少代码重复。