### PR TITLE
chore: 使用`keydown`替换`keypress`，`keypress`事件已弃用

### DIFF
--- a/src/views/login/index.vue
+++ b/src/views/login/index.vue
@@ -96,7 +96,8 @@ const immediateDebounce: any = debounce(
   true
 );
 
-useEventListener(document, "keypress", ({ code }) => {
+useEventListener(document, "keydown", ({ code }) => {
+  console.log(code);
   if (
     ["Enter", "NumpadEnter"].includes(code) &&
     !disabled.value &&

--- a/src/views/login/index.vue
+++ b/src/views/login/index.vue
@@ -97,7 +97,6 @@ const immediateDebounce: any = debounce(
 );
 
 useEventListener(document, "keydown", ({ code }) => {
-  console.log(code);
   if (
     ["Enter", "NumpadEnter"].includes(code) &&
     !disabled.value &&


### PR DESCRIPTION
keypress事件已弃用，不推荐再使用，建议改为keydown事件，谢谢
MDN参考链接：https://developer.mozilla.org/zh-CN/docs/Web/API/Element/keypress_event