### PR TITLE
fix: 修复resetRouter未清空全部路由数据

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -10,9 +10,9 @@ import { usePermissionStoreHook } from "@/store/modules/permission";
 import {
   isUrl,
   openLink,
-  storageLocal,
+  cloneDeep,
   isAllEmpty,
-  cloneDeep
+  storageLocal
 } from "@pureadmin/utils";
 import {
   ascending,
@@ -27,9 +27,9 @@ import {
 } from "./utils";
 import {
   type Router,
-  createRouter,
   type RouteRecordRaw,
-  type RouteComponent
+  type RouteComponent,
+  createRouter
 } from "vue-router";
 import {
   type DataInfo,
@@ -61,7 +61,7 @@ export const constantRoutes: Array<RouteRecordRaw> = formatTwoStageRoutes(
   formatFlatteningRoutes(buildHierarchyTree(ascending(routes.flat(Infinity))))
 );
 
-/** 初始的静态路由，用来在退出登陆时重置路由 */
+/** 初始的静态路由，用于退出登陆时重置路由 */
 const initConstantRoutes: Array<RouteRecordRaw> = cloneDeep(constantRoutes);
 
 /** 用于渲染菜单，保持原始层级 */

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -7,7 +7,13 @@ import { buildHierarchyTree } from "@/utils/tree";
 import remainingRouter from "./modules/remaining";
 import { useMultiTagsStoreHook } from "@/store/modules/multiTags";
 import { usePermissionStoreHook } from "@/store/modules/permission";
-import { isUrl, openLink, storageLocal, isAllEmpty } from "@pureadmin/utils";
+import {
+  isUrl,
+  openLink,
+  storageLocal,
+  isAllEmpty,
+  cloneDeep
+} from "@pureadmin/utils";
 import {
   ascending,
   getTopMenu,
@@ -55,6 +61,9 @@ export const constantRoutes: Array<RouteRecordRaw> = formatTwoStageRoutes(
   formatFlatteningRoutes(buildHierarchyTree(ascending(routes.flat(Infinity))))
 );
 
+/** 初始的静态路由，用来在退出登陆时重置路由 */
+const initConstantRoutes: Array<RouteRecordRaw> = cloneDeep(constantRoutes);
+
 /** 用于渲染菜单，保持原始层级 */
 export const constantMenus: Array<RouteComponent> = ascending(
   routes.flat(Infinity)
@@ -87,17 +96,13 @@ export const router: Router = createRouter({
 
 /** 重置路由 */
 export function resetRouter() {
-  router.getRoutes().forEach(route => {
-    const { name, meta } = route;
-    if (name && router.hasRoute(name) && meta?.backstage) {
-      router.removeRoute(name);
-      router.options.routes = formatTwoStageRoutes(
-        formatFlatteningRoutes(
-          buildHierarchyTree(ascending(routes.flat(Infinity)))
-        )
-      );
-    }
-  });
+  router.clearRoutes();
+  for (const route of initConstantRoutes.concat(...(remainingRouter as any))) {
+    router.addRoute(route);
+  }
+  router.options.routes = formatTwoStageRoutes(
+    formatFlatteningRoutes(buildHierarchyTree(ascending(routes.flat(Infinity))))
+  );
   usePermissionStoreHook().clearAllCachePage();
 }
 

--- a/src/router/utils.ts
+++ b/src/router/utils.ts
@@ -172,6 +172,8 @@ function handleAsyncRoutes(routeList) {
           const flattenRouters: any = router
             .getRoutes()
             .find(n => n.path === "/");
+          // 保持router.options.routes[0].children与path为"/"的children一致，防止数据不一致导致异常
+          flattenRouters.children = router.options.routes[0].children;
           router.addRoute(flattenRouters);
         }
       }


### PR DESCRIPTION
修复如下问题：
    在管理员登录并退出后，path为'/'下的children信息未被重置；
    下个普通用户登录时，管理员相关路由页面也能被此普通用户正常访问。

相关issue：
    #1040