### PR TITLE
fix: 项目`settings.json`添加 Tailwind IntelliSense 推荐配置

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,7 +19,8 @@
     "strings": true
   },
   "files.associations": {
-    "editor.snippetSuggestions": "top"
+    "editor.snippetSuggestions": "top",
+    "*.css": "tailwindcss"
   },
   "[css]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"


### PR DESCRIPTION
### 背景

在使用 vue-pure-admin 进行开发时，发现了一个影响开发体验的 VSCode 细节配置问题。

当开发者使用 VSCode 或 Cursor 打开 `src/style/tailwind.css` 文件时，会出现大量 PostCSS 语法错误，尽管项目本身可以完全正常运行。

**具体报错信息如下：**

<img width="580" height="297" alt="image" src="https://github.com/user-attachments/assets/14b39b2e-6d53-48bb-b136-becfdaba6776" />

---

### 问题分析

**现状：**

1. 项目已经在 `.vscode/extensions.json` 中推荐了相关插件：
   - `bradlc.vscode-tailwindcss` - Tailwind CSS IntelliSense
   - `csstools.postcss` - PostCSS Language Support

2. 项目使用 Tailwind CSS v4，其语法包含了新的指令如：
   - `@custom-variant` - 自定义变体
   - `@theme` - 主题配置
   - `@utility` - 自定义工具类

**问题原因：**

这个问题很可能是由于配置缺失导致的。经验丰富的开发者通常不会遇到此类问题，因为他们会在用户设置（`settings`）中提前完成插件的正确配置。

`pureAdmin` 非常友好，它会在 `.vscode\extensions.json` 文件中推荐相关插件。但是，**插件推荐不等于自动配置**。并非所有开发者都会主动去学习和调整 VS Code 的设置。即便安装了 `bradlc.vscode-tailwindcss` 插件，若未在 `settings.json` 中配置 `files.associations`，VS Code 仍会默认使用 CSS/PostCSS 解析器处理 `.css` 文件。而该默认解析器无法识别 Tailwind v4 的特殊语法，最终便会引发报错。

**影响范围：**

- 对新手开发者影响最大，容易误以为项目代码有语法错误
- 使用 Cursor 编辑器的开发者也会遇到同样问题
- 影响开发体验和代码编写效率
- 可能导致开发者对项目质量产生怀疑

---

### 当前修改

仅仅只是在 `.vscode/settings.json` 中添加 Tailwind CSS IntelliSense [官方推荐的文件关联配置](https://github.com/tailwindlabs/tailwindcss-intellisense?tab=readme-ov-file#recommended-vs-code-settings
)

```json
"files.associations": {
  "*.css": "tailwindcss"
}
```

当然，如果开发者非常谨慎，上面的配置也可以写成`**/style/tailwind.css": "tailwindcss`。但官方定义如此，可能是为了后续其他的 CSS 地方使用 Tailwind 语法做准备。毕竟在一个完整的项目中，可能不止一个文件会用到 Tailwind 的特殊指令。

可能会有开发者担心："配置 `"*.css": "tailwindcss"` 是否会影响项目中其他非 Tailwind 的纯 CSS 文件？"

**实际情况是：** Tailwind CSS IntelliSense 插件在设计上完全兼容标准 CSS 语法，下面的说明来自插件主页：

> An alternative to VS Code's built-in CSS language mode which maintains full CSS IntelliSense support even when using Tailwind-specific at-rules. Syntax definitions are also provided so that Tailwind-specific syntax is highlighted correctly in all CSS contexts.

还有，为什么只配置 `*.css` 而不包含 `*.scss`：

1. 根据 Tailwind 官方文档，只推荐将 `.css` 文件关联到 `tailwindcss` 解析器
2. 项目中的 SCSS 文件（如 `sidebar.scss`、`theme.scss` 等）使用标准 SCSS 语法（`@mixin`、`@include`、`$variables`），应该由默认的 SCSS 解析器处理
3. 如果将 `*.scss` 也关联到 `tailwindcss`，会导致 SCSS 特有语法被误报为错误

---

### 重要！： 关于 Vue 单文件组件中的 @apply 报错

我也发现，在 Vue 单文件组件的 `<style>` 块中使用 `@apply` 指令时也会遇到报错。

对此网上有多种解决方案：

1. 安装 PostCSS Language Support 插件
2. 使用 `<style lang="postcss">`
3. 配置 stylelint 忽略相关规则
4. 设置 `"css.lint.unknownAtRules": "ignore"`

详见stackoverflow的讨论：
[duplicate "Unknown at rule @apply css(unknownAtRules)" errors in Vue.js project](https://stackoverflow.com/questions/71648391/duplicate-unknown-at-rule-apply-cssunknownatrules-errors-in-vue-js-project)

需要注意的是，创始人 Adam Wathan 并不推荐在 Vue 的 `<style>` 中书写 Tailwind 语法。他写道：
> "A ton of confusion amongst Tailwind users comes from not realizing that if you are using CSS modules, or `<style>` blocks in Vue/Svelte/Astro, your CSS pipeline separately for every single one of those blocks. 50 Vue components using `<style>` means Tailwind runs 50 separate times."

**在 Vue `<style>` 块中使用 Tailwind 指令并非最佳实践**：

- 每个 `<style>` 块都会触发单独的 CSS 编译过程
- 50 个 Vue 组件意味着 Tailwind 需要运行 50 次
- 性能开销大，且容易出现各种兼容性问题

**官方推荐的最佳实践：**

- 直接在模板中使用 Tailwind 类名
- 或者使用 CSS 变量来管理样式
- 避免在 `<style>` 块中大量使用 `@apply`

所以，我虽然也遇到了`@apply` 指令的报错，但是我不准备修复它，并且以后也会避免这种写法。

以上就是本次PR的全部描述，谢谢。

---

### 参考资料

1. **Tailwind CSS IntelliSense 官方 vs code 推荐配置**  
   <https://github.com/tailwindlabs/tailwindcss-intellisense?tab=readme-ov-file#recommended-vs-code-settings>  

2. **StackOverflow讨论：Tailwind CSS v4 未知规则报错的完整解决方案**  
   <https://stackoverflow.com/questions/79513015/tailwind-css-v4-unknown-at-rule-plugin-custom-variant-theme-utility-v/79513027#79513027>  

3. **关于 @apply 使用的深度分析和最佳实践建议**  
   <https://stackoverflow.com/a/79449440/15167500>  
   rozsazoltan 的详细分析，引用了 Adam Wathan 的重要观点："@apply 功能基本上只是为了诱使那些被长长的类列表吓到的人尝试这个框架而存在的。你几乎永远不应该使用它。" 文章详细解释了为什么应该避免在 Vue/Svelte/Astro 的 `<style>` 块中使用 Tailwind 特性，以及性能和架构方面的考量。

4. **PostCSS 语言支持的替代方案**  
   <https://stackoverflow.com/a/79437043/15167500>  
   yoduh 提供的技术方案：在 Vue 单文件组件中使用 `<style scoped lang="postcss">` 来解决 `@apply` 报错问题，并推荐安装 language-postcss 扩展来保持语法高亮。

5. **GitHub 官方讨论：@apply 未知规则问题的多种解决方案**  
   <https://github.com/tailwindlabs/tailwindcss/discussions/5258>  
   社区长期讨论帖，mrfambo 提供了 2023 年推荐的修复方案：通过创建 `.vscode/settings.json` 和 `.vscode/tailwind.json` 文件，使用 `css.customData` 配置来定义 Tailwind 的 at-rules，从而让 VSCode 识别这些特殊指令。据我看来，现在似乎已经过时。

6. **VSCode PostCSS 语言支持插件**  
   <https://marketplace.visualstudio.com/items?itemName=cpylua.language-postcss>  

7. **Adam Wathan 关于 Tailwind 性能最佳实践的推文系列**  

   - **性能问题核心观点** (<https://x.com/adamwathan/status/1890404835888910467>)  
     "许多 Tailwind 用户产生困惑的原因是，他们没有意识到如果在 CSS 模块或 Vue/Svelte/Astro 的 `<style>` 块中使用 Tailwind，CSS 管道会为每一个这样的块单独运行一次。50 个使用 `<style>` 的 Vue 组件意味着 Tailwind 要运行 50 次。"

   - **推荐使用 CSS 变量** (<https://x.com/adamwathan/status/1890405698153972130>)  
     "为了获得最佳构建性能，不要在 CSS 模块或 Vue/Svelte/Astro 的 `<style>` 块中使用 Tailwind 特性，而是依赖 CSS 变量。"

   - **最佳实践：直接使用类名** (<https://x.com/adamwathan/status/1890406016291938701>)  
     "或者更好的做法是，直接在标记中使用类名，这才是你应该做的。"

   - **关于 CSS 文件导入的性能建议** (<https://x.com/adamwathan/status/1890406873586622932>)  
     "顺便说一下，在 JavaScript 中导入多个 CSS 文件也会发生同样的问题。不要那样做——把它们都导入到一个 CSS 文件中，然后在 JS 中加载那一个文件。"
