### PR TITLE
fix: 修复在内嵌同源`iframe`页面中，当其注册了`beforeunload`事件时，右键标签页点击`重新加载`导致浏览器弹出两次确认拦截的问题

### DIFF
--- a/src/layout/frame.vue
+++ b/src/layout/frame.vue
@@ -45,6 +45,7 @@ function init() {
   });
 }
 
+let isRedirect = false;
 watch(
   () => currentRoute.fullPath,
   path => {
@@ -52,12 +53,19 @@ watch(
       currentRoute.name === "Redirect" &&
       path.includes(props.frameInfo?.fullPath)
     ) {
-      frameSrc.value = path; // redirect时，置换成任意值，待重定向后 重新赋值
+      isRedirect = true;
       loading.value = true;
     }
     // 重新赋值
     if (props.frameInfo?.fullPath === path) {
       frameSrc.value = props.frameInfo?.frameSrc;
+      if (isRedirect) {
+        let joinChar = new URL(props.frameInfo.frameSrc)?.search ? "&" : "?";
+        frameSrc.value =
+          props.frameInfo.frameSrc + `${joinChar}t=` + Date.now();
+        hideLoading();
+      }
+      isRedirect = false;
     }
   }
 );

--- a/src/layout/frame.vue
+++ b/src/layout/frame.vue
@@ -19,13 +19,22 @@ const loading = ref(true);
 const currentRoute = useRoute();
 const frameSrc = ref<string>("");
 const frameRef = ref<HTMLElement | null>(null);
+const fallbackTimer = ref<number | null>(null);
+
 if (unref(currentRoute.meta)?.frameSrc) {
   frameSrc.value = unref(currentRoute.meta)?.frameSrc as string;
 }
-unref(currentRoute.meta)?.frameLoading === false && hideLoading();
+
+function clearFallbackTimer() {
+  if (fallbackTimer.value !== null) {
+    clearTimeout(fallbackTimer.value);
+    fallbackTimer.value = null;
+  }
+}
 
 function hideLoading() {
   loading.value = false;
+  clearFallbackTimer();
 }
 
 function init() {
@@ -34,40 +43,42 @@ function init() {
     if (!iframe) return;
     const _frame = iframe as any;
     if (_frame.attachEvent) {
-      _frame.attachEvent("onload", () => {
-        hideLoading();
-      });
+      _frame.attachEvent("onload", hideLoading);
     } else {
-      iframe.onload = () => {
-        hideLoading();
-      };
+      iframe.onload = hideLoading;
     }
   });
 }
 
 let isRedirect = false;
+
 watch(
   () => currentRoute.fullPath,
   path => {
     if (
       currentRoute.name === "Redirect" &&
-      path.includes(props.frameInfo?.fullPath)
+      props.frameInfo?.fullPath &&
+      path.includes(props.frameInfo.fullPath)
     ) {
       isRedirect = true;
       loading.value = true;
+      return;
     }
-    // 重新赋值
-    if (props.frameInfo?.fullPath === path) {
-      frameSrc.value = props.frameInfo?.frameSrc;
-      if (isRedirect) {
-        let joinChar = new URL(props.frameInfo.frameSrc)?.search ? "&" : "?";
-        frameSrc.value =
-          props.frameInfo.frameSrc + `${joinChar}t=` + Date.now();
-        hideLoading();
-      }
+    if (props.frameInfo?.fullPath === path && isRedirect) {
+      loading.value = true;
+      clearFallbackTimer();
+      const url = new URL(props.frameInfo.frameSrc, window.location.origin);
+      const joinChar = url.search ? "&" : "?";
+      frameSrc.value = `${props.frameInfo.frameSrc}${joinChar}t=${Date.now()}`;
+      fallbackTimer.value = window.setTimeout(() => {
+        if (loading.value) {
+          hideLoading();
+        }
+      }, 1500);
       isRedirect = false;
     }
-  }
+  },
+  { immediate: true }
 );
 
 onMounted(() => {


### PR DESCRIPTION
修改`重新加载`时frame组件控制iframe的方式，防止出现两次拦截确认导致的问题。